### PR TITLE
Add cache busting support

### DIFF
--- a/forest-fires/app/index.html
+++ b/forest-fires/app/index.html
@@ -7,7 +7,7 @@
 	<title>Raster Foundry - BC Wild Fires</title>
 
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,700|Titillium+Web:400,600,700" rel="stylesheet">
-	<link rel="stylesheet" href="./assets/css/main.css">
+	<link rel="stylesheet" href="assets/css/main.css">
   </head>
   <body>
 	<div class="app-container">

--- a/forest-fires/grunt/aliases.yaml
+++ b/forest-fires/grunt/aliases.yaml
@@ -9,3 +9,4 @@ build:
   - 'sass:dist'
   - 'postcss:dist'
   - 'copy:dist'
+  - 'cacheBust:dist'

--- a/forest-fires/grunt/cacheBust.js
+++ b/forest-fires/grunt/cacheBust.js
@@ -1,0 +1,13 @@
+module.exports = {
+    dist: {
+        options: {
+            assets: [
+                'assets/js/*',
+                'assets/css/*'
+            ],
+            baseDir: 'dist',
+            queryString: true
+        },
+        src: ['dist/index.html']
+    }
+};

--- a/forest-fires/package.json
+++ b/forest-fires/package.json
@@ -7,6 +7,7 @@
         "cssnano": "^3.5.2",
         "grunt": "^0.4.5",
         "grunt-browser-sync": "^2.2.0",
+        "grunt-cache-bust": "^1.6.0",
         "grunt-contrib-clean": "^1.1.0",
         "grunt-contrib-copy": "^1.0.0",
         "grunt-contrib-watch": "^1.0.0",

--- a/forest-fires/yarn.lock
+++ b/forest-fires/yarn.lock
@@ -960,7 +960,7 @@ fresh@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.3.0.tgz#651f838e22424e7566de161d8358caa199f83d4f"
 
-fs-extra@3.0.1:
+fs-extra@3.0.1, fs-extra@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
   dependencies:
@@ -1107,6 +1107,12 @@ grunt-browser-sync@^2.2.0:
   resolved "https://registry.yarnpkg.com/grunt-browser-sync/-/grunt-browser-sync-2.2.0.tgz#a0e9c1fd1ccb5c454c25ec5170113ffff06a4772"
   dependencies:
     browser-sync "^2.6.4"
+
+grunt-cache-bust@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/grunt-cache-bust/-/grunt-cache-bust-1.6.0.tgz#0dea4012ccedcca629b02e815995f383574ecf66"
+  dependencies:
+    fs-extra "^3.0.1"
 
 grunt-contrib-clean@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Make use of the grunt-cache-bust plugin to add query string checksums to JavaScript and CSS files so that they break through any layers of caching.

---

**Testing**

```bash
root@1620f6579ebd:/usr/local/src/forest-fires# grep "main." dist/index.html 
        <link rel="stylesheet" href="assets/css/main.css?c6ab497bd2446240">
          <div class="main-nav">
        <script src="assets/js/main.js?284330ac64fb903c"></script>
```